### PR TITLE
add weights to `gregElasticNet` output

### DIFF
--- a/R/gregElasticNet.R
+++ b/R/gregElasticNet.R
@@ -174,6 +174,9 @@ if (model == "linear") {
     xpop_d <- unlist(c(N,xpop[names(xsample)]*N))
   }
   
+  # Compute weights
+  w <- as.matrix(1 + t(as.matrix(xpop_d) - xsample.dt %*% weight) %*% solve(xsample.dt %*% diag(weight) %*% xsample.d) %*% (xsample.dt)) %*% diag(weight)
+  
   #Total estimate
   t <- elasticNet_coef %*% (xpop_d) + t(y-y.hats.s)%*%pi^(-1)
   
@@ -206,11 +209,13 @@ if (model == "linear") {
                  pop_mean = as.numeric(t)/N, 
                  pop_total_var=varEst, 
                  pop_mean_var=varEst/N^2,
+                 weights = as.vector(w),
                  coefficients = elasticNet_coef))
   }else{
     
     return(list( pop_total = as.numeric(t), 
                  pop_mean = as.numeric(t)/N, 
+                 weights = as.vector(w),
                  coefficients = elasticNet_coef))
     
   }

--- a/R/gregElasticNet.R
+++ b/R/gregElasticNet.R
@@ -8,7 +8,7 @@
 #' @param alpha A numeric value between 0 and 1 which signifies the mixing parameter for the lasso and ridge penalties in the elastic net.  When alpha = 1, only a lasso penalty is used.  When alpha = 0, only a ridge penalty is used. Default is alpha = 1. 
 #' @param lambda A string specifying how to tune the lambda hyper-parameter.  Only used if modelselect = TRUE and defaults to "lambda.min". The possible values are "lambda.min", which is the lambda value associated with the minimum cross validation error or "lambda.1se", which is the lambda value associated with a cross validation error that is one standard error away from the minimum, resulting in a smaller model.
 #' @param cvfolds The number of folds for the cross-validation to tune lambda.
-#' @param weights_method A string specifying which method to use to calculate survey weights. Defaults to "calibration". The possible values are "calibration", which employs the model calibration method of Wu and Sitter (2001) or "ridge", which uses a ridge regression approximation to calculate weights (see McConville et al (2017), section 3.2 for details).
+#' @param weights_method A string specifying which method to use to calculate survey weights. Currently, "ridge" is the only option. The "ridge" method uses a ridge regression approximation to calculate weights (see McConville et al (2017), section 3.2 for details). Support for "calibration" to come soon, which employs the model calibration method of Wu and Sitter (2001).
 #' @param eta A small positive number. Defaults to 0.0001. See McConville et al (2017), section 3.2 for details. 
 #' 
 #' @examples 
@@ -39,7 +39,7 @@
 #' @include gregElasticNett.R
 
 gregElasticNet  <- function(
-  y, xsample, xpop, pi = NULL, alpha=1, model="linear", pi2 = NULL, var_est =FALSE, var_method="LinHB", datatype = "raw", N = NULL, lambda = "lambda.min", B = 1000, cvfolds = 10, weights_method = "calibration", eta = 0.0001){
+  y, xsample, xpop, pi = NULL, alpha=1, model="linear", pi2 = NULL, var_est =FALSE, var_method="LinHB", datatype = "raw", N = NULL, lambda = "lambda.min", B = 1000, cvfolds = 10, weights_method = "ridge", eta = 0.0001){
   
   
   ### INPUT VALIDATION ###
@@ -177,12 +177,12 @@ if (model == "linear") {
   }
   
   # Compute weights
-  if (weights_method == "calibration") {
-    # not correct, currently
-    # w <- as.matrix(1 + t(as.matrix(xpop_d) - xsample.dt %*% weight) %*% solve(xsample.dt %*% diag(weight) %*% xsample.d) %*% (xsample.dt)) %*% diag(weight)
-    print("weights_method 'calibration' not yet supported. Using 'ridge' instead.")
-    weights_method <- "ridge"
-  }
+  # if (weights_method == "calibration") {
+  #   # not correct, currently
+  #   # w <- as.matrix(1 + t(as.matrix(xpop_d) - xsample.dt %*% weight) %*% solve(xsample.dt %*% diag(weight) %*% xsample.d) %*% (xsample.dt)) %*% diag(weight)
+  #   print("weights_method 'calibration' not yet supported. Using 'ridge' instead.")
+  #   weights_method <- "ridge"
+  # }
   if (weights_method == "ridge") {
     abs_beta_hat <- abs(c(0, elasticNet_coef[2:length(elasticNet_coef)]))
     Q_inverse <- diag(abs_beta_hat + eta)

--- a/R/gregElasticNet.R
+++ b/R/gregElasticNet.R
@@ -8,6 +8,8 @@
 #' @param alpha A numeric value between 0 and 1 which signifies the mixing parameter for the lasso and ridge penalties in the elastic net.  When alpha = 1, only a lasso penalty is used.  When alpha = 0, only a ridge penalty is used. Default is alpha = 1. 
 #' @param lambda A string specifying how to tune the lambda hyper-parameter.  Only used if modelselect = TRUE and defaults to "lambda.min". The possible values are "lambda.min", which is the lambda value associated with the minimum cross validation error or "lambda.1se", which is the lambda value associated with a cross validation error that is one standard error away from the minimum, resulting in a smaller model.
 #' @param cvfolds The number of folds for the cross-validation to tune lambda.
+#' @param weights_method A string specifying which method to use to calculate survey weights. Defaults to "calibration". The possible values are "calibration", which employs the model calibration method of Wu and Sitter (2001) or "ridge", which uses a ridge regression approximation to calculate weights (see McConville et al (2017), section 3.2 for details).
+#' @param eta A small positive number. Defaults to 0.0001. See McConville et al (2017), section 3.2 for details. 
 #' 
 #' @examples 
 #' library(survey)
@@ -37,7 +39,7 @@
 #' @include gregElasticNett.R
 
 gregElasticNet  <- function(
-  y, xsample, xpop, pi = NULL, alpha=1, model="linear", pi2 = NULL, var_est =FALSE, var_method="LinHB", datatype = "raw", N = NULL, lambda = "lambda.min", B = 1000, cvfolds = 10){
+  y, xsample, xpop, pi = NULL, alpha=1, model="linear", pi2 = NULL, var_est =FALSE, var_method="LinHB", datatype = "raw", N = NULL, lambda = "lambda.min", B = 1000, cvfolds = 10, weights_method = "calibration", eta = 0.0001){
   
   
   ### INPUT VALIDATION ###
@@ -175,8 +177,18 @@ if (model == "linear") {
   }
   
   # Compute weights
-  w <- as.matrix(1 + t(as.matrix(xpop_d) - xsample.dt %*% weight) %*% solve(xsample.dt %*% diag(weight) %*% xsample.d) %*% (xsample.dt)) %*% diag(weight)
-  
+  if (weights_method == "calibration") {
+    # not correct, currently
+    # w <- as.matrix(1 + t(as.matrix(xpop_d) - xsample.dt %*% weight) %*% solve(xsample.dt %*% diag(weight) %*% xsample.d) %*% (xsample.dt)) %*% diag(weight)
+    print("weights_method 'calibration' not yet supported. Using 'ridge' instead.")
+    weights_method <- "ridge"
+  }
+  if (weights_method == "ridge") {
+    abs_beta_hat <- abs(c(0, elasticNet_coef[2:length(elasticNet_coef)]))
+    Q_inverse <- diag(abs_beta_hat + eta)
+    w <- as.matrix(1 + t(as.matrix(xpop_d) - xsample.dt %*% weight) %*% solve(xsample.dt %*% diag(weight) %*% xsample.d + Q_inverse) %*% (xsample.dt)) %*% diag(weight)
+  }
+
   #Total estimate
   t <- elasticNet_coef %*% (xpop_d) + t(y-y.hats.s)%*%pi^(-1)
   


### PR DESCRIPTION
Hi @mcconvil! When using `mase` in `FIESTA` Tracey and I came across an issue of `gregElasticNet` not outputting weights. I took code from your `greg` function to add in the weights to `gregElasticNet`, with no code or variable names changed when moving it over. I may be missing something big here, but I wanted to send the PR in case all is well with the code.